### PR TITLE
Explore preprocessing strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+datasets

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 
 datasets
+source_*

--- a/preprocessing/README.md
+++ b/preprocessing/README.md
@@ -1,0 +1,18 @@
+# Preprocessing Techniques
+
+On the surface, pre-processing is quite straightforward.
+All we're doing to taking data and transforming it into
+some format we want (i.e. binary, chunks, numerical,
+etc.). 
+
+However, the problem is that it's such a simple idea that
+everyone just rolls their own pre-processing method. I
+don't think we should standardize it, but we should all
+have some idea of the most elegant path.
+
+![image](https://github.com/hitorilabs/papers/assets/131238467/9597fe82-0d20-4af7-bf91-acfff08d68d9)
+
+
+https://gist.github.com/ZijiaLewisLu/eabdca955110833c0ce984d34eb7ff39?permalink_comment_id=3417135
+
+just use `np.memmap` for everything - it's all tensors.

--- a/preprocessing/multi_file_example.py
+++ b/preprocessing/multi_file_example.py
@@ -2,9 +2,11 @@ import pandas as pd
 import numpy as np
 import pathlib
 import os
+from tqdm import tqdm
 
 # one-liner for copying data 
 # for((i=1; i <= 100; i++)); do cp source_iris/iris.data "iris_dataset/iris_${i}.data"; done
+
 source_path = os.getenv("SOURCE_PATH")
 if source_path is None: raise Exception("Missing SOURCE_PATH variable")
 
@@ -17,10 +19,9 @@ data_path.mkdir(exist_ok=True)
 
 rows = 0
 cols = 0
-for i, file in enumerate(source_path.glob(pattern)):
+for i, file in enumerate(tqdm(list(source_path.glob(pattern)))):
     df = pd.read_csv(file, header=None)
     df_rows, df_cols = df.shape
-    print(df.shape, i)
     rows += df_rows
     cols = df_cols
 
@@ -28,7 +29,7 @@ train_file = np.memmap(data_path / "train.memmap", dtype='float32', mode='w+', s
 target_file = np.memmap(data_path / "target.memmap", dtype='int64', mode='w+', shape=(rows))
 
 current_rows = 0
-for i, file in enumerate(source_path.glob(pattern)):
+for i, file in enumerate(tqdm(list(source_path.glob(pattern)))):
     df = pd.read_csv(
             file, 
             header=None,
@@ -62,4 +63,3 @@ for i, file in enumerate(source_path.glob(pattern)):
     target_file.flush()
 
     current_rows += rows
-    print("loaded", i)

--- a/preprocessing/multi_file_example.py
+++ b/preprocessing/multi_file_example.py
@@ -63,5 +63,3 @@ for i, file in enumerate(source_path.glob(pattern)):
 
     current_rows += rows
     print("loaded", i)
-
-print(np.memmap("datasets/iris_dataset/train.memmap", dtype='float32', mode='r'))

--- a/preprocessing/multi_file_example.py
+++ b/preprocessing/multi_file_example.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import numpy as np
+import pathlib
+import os
+
+# one-liner for copying data 
+# for((i=1; i <= 100; i++)); do cp source_iris/iris.data "iris_dataset/iris_${i}.data"; done
+source_path = os.getenv("SOURCE_PATH")
+if source_path is None: raise Exception("Missing SOURCE_PATH variable")
+
+pattern = os.getenv("PATTERN")
+if pattern is None: raise Exception("Missing PATTERN variable")
+
+source_path = pathlib.Path(".") / source_path
+data_path = pathlib.Path("datasets") / source_path.stem
+data_path.mkdir(exist_ok=True)
+
+rows = 0
+cols = 0
+for i, file in enumerate(source_path.glob(pattern)):
+    df = pd.read_csv(file, header=None)
+    df_rows, df_cols = df.shape
+    print(df.shape, i)
+    rows += df_rows
+    cols = df_cols
+
+train_file = np.memmap(data_path / "train.memmap", dtype='float32', mode='w+', shape=(rows, cols -1))
+target_file = np.memmap(data_path / "target.memmap", dtype='int64', mode='w+', shape=(rows))
+
+current_rows = 0
+for i, file in enumerate(source_path.glob(pattern)):
+    df = pd.read_csv(
+            file, 
+            header=None,
+            names=[
+                "sepal_length", 
+                "sepal_width", 
+                "petal_length", 
+                "petal_width", 
+                "class"
+            ],
+            dtype={
+                "sepal_length": np.float32, 
+                "sepal_width": np.float32, 
+                "petal_length": np.float32, 
+                "petal_width": np.float32, 
+                "class": "category",
+            })
+    xs, ys = (
+        df.loc[:, df.columns != "class"].to_numpy(), 
+        df["class"].cat.codes.to_numpy(dtype="int64"),
+    )
+
+    rows, cols = xs.shape
+    left_pos = current_rows
+    right_pos = current_rows + rows
+
+    train_file[left_pos:right_pos,:cols] = xs[:rows,:cols]
+    train_file.flush()
+
+    target_file[left_pos:right_pos] = ys[:rows]
+    target_file.flush()
+
+    current_rows += rows
+    print("loaded", i)
+
+print(np.memmap("datasets/iris_dataset/train.memmap", dtype='float32', mode='r'))

--- a/preprocessing/save_v_mmap.py
+++ b/preprocessing/save_v_mmap.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import pathlib
+
+data_path = pathlib.Path("datasets")
+data_path.mkdir(exist_ok=True)
+
+df = pd.read_csv(
+    "1958-perceptron/iris.data", 
+    header=None,
+    names=[
+        "sepal_length", 
+        "sepal_width", 
+        "petal_length", 
+        "petal_width", 
+        "class"
+    ],
+    dtype={
+        "sepal_length": np.float32, 
+        "sepal_width": np.float32, 
+        "petal_length": np.float32, 
+        "petal_width": np.float32, 
+        "class": "category",
+    },
+    engine="pyarrow"
+    )
+
+xs, ys = (
+    df.loc[:, df.columns != "class"].to_numpy(), 
+    df["class"].cat.codes.to_numpy()
+)
+
+
+np.save(data_path / "train_save.npy", xs)
+np.save(data_path / "target_save.npy", ys)
+
+rows, *_ = xs.shape
+fp = np.memmap(data_path / "train_memmap.npy", dtype='float32', mode='w+', shape=xs.shape)
+fp[:rows] = xs[:rows]
+fp.flush()
+
+rows, *_ = ys.shape
+fp = np.memmap(data_path / "target_memmap.npy", dtype="int64", mode='w+', shape=ys.shape)
+fp[:rows] = ys[:rows]
+fp.flush()

--- a/preprocessing/save_v_mmap.py
+++ b/preprocessing/save_v_mmap.py
@@ -1,13 +1,16 @@
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 import pathlib
+import os
 
-data_path = pathlib.Path("datasets")
+source_file = os.getenv("SOURCE_FILE")
+if source_file is None: raise Exception("Missing SOURCE_FILE variable")
+source_path = pathlib.Path(".") / source_file
+data_path = pathlib.Path("datasets") / source_path.stem
 data_path.mkdir(exist_ok=True)
 
 df = pd.read_csv(
-    "1958-perceptron/iris.data", 
+    source_path, 
     header=None,
     names=[
         "sepal_length", 
@@ -22,15 +25,15 @@ df = pd.read_csv(
         "petal_length": np.float32, 
         "petal_width": np.float32, 
         "class": "category",
-    },
-    engine="pyarrow"
-    )
+    })
 
 xs, ys = (
-    df.loc[:, df.columns != "class"].to_numpy(), 
-    df["class"].cat.codes.to_numpy()
+    np.repeat(df.loc[:, df.columns != "class"].to_numpy(),   1000000), 
+    np.repeat(df["class"].cat.codes.to_numpy(dtype="int64"), 1000000),
 )
 
+print(xs.shape)
+print(ys.shape)
 
 np.save(data_path / "train_save.npy", xs)
 np.save(data_path / "target_save.npy", ys)
@@ -38,9 +41,11 @@ np.save(data_path / "target_save.npy", ys)
 rows, *_ = xs.shape
 fp = np.memmap(data_path / "train_memmap.npy", dtype='float32', mode='w+', shape=xs.shape)
 fp[:rows] = xs[:rows]
+print(fp.shape)
 fp.flush()
 
 rows, *_ = ys.shape
 fp = np.memmap(data_path / "target_memmap.npy", dtype="int64", mode='w+', shape=ys.shape)
+print(fp.shape)
 fp[:rows] = ys[:rows]
 fp.flush()

--- a/preprocessing/single_file_example.py
+++ b/preprocessing/single_file_example.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import numpy as np
+import pathlib
+import os
+
+source_file = os.getenv("SOURCE_FILE")
+if source_file is None: raise Exception("Missing SOURCE_FILE variable")
+
+source_path = pathlib.Path(".") / source_file
+data_path = pathlib.Path("datasets") / source_path.stem
+data_path.mkdir(exist_ok=True)
+
+df = pd.read_csv(
+    source_path, 
+    header=None,
+    names=[
+        "sepal_length", 
+        "sepal_width", 
+        "petal_length", 
+        "petal_width", 
+        "class"
+    ],
+    dtype={
+        "sepal_length": np.float32, 
+        "sepal_width": np.float32, 
+        "petal_length": np.float32, 
+        "petal_width": np.float32, 
+        "class": "category",
+    })
+
+xs, ys = (
+    df.loc[:, df.columns != "class"].to_numpy(), 
+    df["class"].cat.codes.to_numpy(dtype="int64"),
+)
+
+rows, *_ = xs.shape
+fp = np.memmap(data_path / "train_memmap.npy", dtype='float32', mode='w+', shape=xs.shape)
+fp[:rows] = xs[:rows]
+fp.flush()
+
+rows, *_ = ys.shape
+fp = np.memmap(data_path / "target_memmap.npy", dtype="int64", mode='w+', shape=ys.shape)
+fp[:rows] = ys[:rows]
+fp.flush()

--- a/preprocessing/single_file_example.py
+++ b/preprocessing/single_file_example.py
@@ -34,11 +34,11 @@ xs, ys = (
 )
 
 rows, *_ = xs.shape
-fp = np.memmap(data_path / "train_memmap.npy", dtype='float32', mode='w+', shape=xs.shape)
+fp = np.memmap(data_path / "train.memmap", dtype='float32', mode='w+', shape=xs.shape)
 fp[:rows] = xs[:rows]
 fp.flush()
 
 rows, *_ = ys.shape
-fp = np.memmap(data_path / "target_memmap.npy", dtype="int64", mode='w+', shape=ys.shape)
+fp = np.memmap(data_path / "target.memmap", dtype="int64", mode='w+', shape=ys.shape)
 fp[:rows] = ys[:rows]
 fp.flush()


### PR DESCRIPTION
- `np.memmap` loses shape information when you load it in again (this doesn't really produce `npy` files)
  - only strategy that allows you to save a single file that's bigger than RAM
  - one huge file can't really be parallelized when transferring.
- `np.save` retains this shape info, but you can't append to an existing `npy` file - so you neet to split data into batches.
  - even though you could load a file bigger than RAM with mmap'd read, you can only save a file that fits in RAM.

`np.float32` for training data and `np.int64` to match `torch.long` (we're going to use cross entropy)

original iris (1.2 KB training set, 120KB targets)
```
(.venv) bocchi@hitorilabs:~/papers$ ls -la datasets
total 24
drwxr-xr-x 2 bocchi bocchi 4096 May 21 18:50 .
drwxr-xr-x 7 bocchi bocchi 4096 May 21 18:50 ..
-rw-r--r-- 1 bocchi bocchi 1200 May 21 18:50 target_memmap.npy
-rw-r--r-- 1 bocchi bocchi  278 May 21 18:50 target_save.npy
-rw-r--r-- 1 bocchi bocchi 2400 May 21 18:50 train_memmap.npy
-rw-r--r-- 1 bocchi bocchi 2528 May 21 18:50 train_save.npy
```

iris x1000000 w/ `np.repeat` (2.4 GB training set, 1.2 GB targets)
```
(.venv) [bocchi@hitorilabs papers]$ ls -la datasets/iris
total 7031280
drwxr-xr-x 2 bocchi bocchi       4096 May 22 03:34 .
drwxr-xr-x 3 bocchi bocchi       4096 May 22 03:34 ..
-rw-r--r-- 1 bocchi bocchi 1200000000 May 22 04:09 target_memmap.npy
-rw-r--r-- 1 bocchi bocchi 1200000128 May 22 04:09 target_save.npy
-rw-r--r-- 1 bocchi bocchi 2400000000 May 22 04:09 train_memmap.npy
-rw-r--r-- 1 bocchi bocchi 2400000128 May 22 04:09 train_save.npy
```

It looks like `np.save` adds exactly 128 bytes to the file (most likely just the shape metadata?)